### PR TITLE
Change colour to also depend on the repay bracket

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -158,7 +158,7 @@ const OperatorSelector = (props: {
   )
 }
 
-const getDelayStyle = (delay: number | undefined, repayBracket: RepayBracket|undefined) =>
+const getDelayStyle = (delay: number | undefined, repayBracket: RepayBracket | undefined) =>
   delay === undefined
     ? "bg-white"
     : delay < 15 || repayBracket === undefined

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -158,10 +158,10 @@ const OperatorSelector = (props: {
   )
 }
 
-const getDelayStyle = (delay: number | undefined) =>
+const getDelayStyle = (delay: number | undefined, repayBracket: RepayBracket|undefined) =>
   delay === undefined
     ? "bg-white"
-    : delay < 15
+    : delay < 15 || repayBracket === undefined
     ? "bg-green-500"
     : delay < 30
     ? "bg-yellow-600"
@@ -254,7 +254,7 @@ const DelayCalculator = (props: {
               ) : (
                 <div
                   className={`${getDelayStyle(
-                    props.delay
+                    props.delay, props.repayBracket
                   )} rounded-lg px-2 py-1 font-bold`}
                 >
                   {getDelayText(delay, repayBracket)}
@@ -268,7 +268,7 @@ const DelayCalculator = (props: {
                 <div className="py-1">Single</div>
                 <div
                   className={`${getDelayStyle(
-                    props.delay
+                    props.delay, props.repayBracket
                   )} rounded-lg px-2 py-1 font-bold`}
                 >
                   {repayBracket.single * 100}%
@@ -276,7 +276,7 @@ const DelayCalculator = (props: {
                 <div className="py-1">Return</div>
                 <div
                   className={`${getDelayStyle(
-                    props.delay
+                    props.delay, props.repayBracket
                   )} rounded-lg px-2 py-1 font-bold`}
                 >
                   {repayBracket.return * 100}%
@@ -434,7 +434,7 @@ const TicketList = (props: {
         <div className="flex flex-row gap-4">
           <div className="py-2">Delay repay</div>
           <div
-            className={`rounded-lg p-2 ${getDelayStyle(props.delay)} font-bold`}
+            className={`rounded-lg p-2 ${getDelayStyle(props.delay, props.repayBracket)} font-bold`}
           >
             {repay.toLocaleString("en-GB", {
               style: "currency",


### PR DESCRIPTION
Closes #9 

All the elements which depend on getDelayStyle have both a delay, and a repayBracket prop.
The repayBracket prop is `undefined` when there is no compenstation, so we can add that to the green case.

I will say, nested ternaries is cursed, but is actually readable and I think the best use case here